### PR TITLE
Support multiline comments via newline escape

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -341,6 +341,6 @@ module.exports = grammar({
     _escape_sequence: ($) =>
       token.immediate(seq("\\", /(\"|\\|\/|b|f|n|r|t|u)/)),
     _IDENT: ($) => /([a-zA-Z_][a-zA-Z_0-9]*::)*[a-zA-Z_][a-zA-Z_0-9]*/,
-    comment: ($) => token(prec(-10, /#.*/)),
+    comment: ($) => token(prec(-10, /#(.|\\\n)*/)),
   },
 });

--- a/test_comment_escape
+++ b/test_comment_escape
@@ -1,0 +1,3 @@
+# hello \
+world
+123


### PR DESCRIPTION
Was added in jq 1.8 https://github.com/jqlang/jq/releases/tag/jq-1.8.0 (https://github.com/jqlang/jq/pull/2989)

I'm new to tree-sitter so maybe there is a better way?